### PR TITLE
fix: prevent duplicate auth toasts and enforce login redirect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from "react-router-dom";
 import Layout from "./components/Layout";
+import ProtectedRoute from "./components/ProtectedRoute";
 import Home from "./pages/Home";
 import Seafood from "./pages/Seafood";
 import Souvenirs from "./pages/Souvenirs";
@@ -27,11 +28,46 @@ function App() {
           <Route path="seafood" element={<Seafood />} />
           <Route path="souvenirs" element={<Souvenirs />} />
           <Route path="about" element={<About />} />
-          <Route path="cart" element={<Cart />} />
-          <Route path="checkout" element={<Checkout />} />
-          <Route path="profile" element={<Profile />} />
-          <Route path="profile/buyer" element={<BuyerProfile />} />
-          <Route path="profile/seller" element={<SellerProfile />} />
+          <Route
+            path="cart"
+            element={
+              <ProtectedRoute>
+                <Cart />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="checkout"
+            element={
+              <ProtectedRoute>
+                <Checkout />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="profile"
+            element={
+              <ProtectedRoute>
+                <Profile />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="profile/buyer"
+            element={
+              <ProtectedRoute>
+                <BuyerProfile />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="profile/seller"
+            element={
+              <ProtectedRoute>
+                <SellerProfile />
+              </ProtectedRoute>
+            }
+          />
           <Route path="colors" element={<Colors />} />
         </Route>
         {/* Auth routes without shared layout */}

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import toast from "react-hot-toast";
+
+const ProtectedRoute = ({ children }) => {
+  const location = useLocation();
+  const isLoggedIn = Boolean(localStorage.getItem("auth_token"));
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      // Use a deterministic toast id to avoid duplicates across renders/navigation
+      toast.dismiss("auth-required");
+      toast("Create an account or log in to continue.", {
+        id: "auth-required",
+      });
+    }
+  }, [isLoggedIn]);
+
+  if (!isLoggedIn) {
+    return (
+      <Navigate
+        to="/login"
+        replace
+        state={{ from: location.pathname || "/" }}
+      />
+    );
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
- Add deterministic toast id and dismiss-before-show in ProtectedRoute
- Trigger auth toast in useEffect to avoid double renders
- Redirect unauthenticated users to login with preserved return path